### PR TITLE
fix: Complete response structure migration to getData() helper

### DIFF
--- a/tests/api/features/client-management/crud-operations/happy-path/typed-client-crud.api.spec.ts
+++ b/tests/api/features/client-management/crud-operations/happy-path/typed-client-crud.api.spec.ts
@@ -48,13 +48,13 @@ describe('Client Management - CRUD with Typed NPM Packages', () => {
 
     // Assert - Response is typed based on OpenAPI schema
     expect(response).toBeDefined();
-    expect((response as any).id).toBeTruthy();
-    expect((response as any).name).toBe(clientData.name);
-    expect((response as any).email).toBe(clientData.email);
-    expect((response as any).status).toBe('Active');
+    expect(response.data.id).toBeTruthy();
+    expect(response.data.name).toBe(clientData.name);
+    expect(response.data.email).toBe(clientData.email);
+    expect(response.data.status).toBe('Active');
     
     // Track for cleanup
-    createdClientIds.push((response as any).id);
+    createdClientIds.push(response.data.id);
   });
 
   test('should get client by ID with typed client', async () => {
@@ -68,7 +68,7 @@ describe('Client Management - CRUD with Typed NPM Packages', () => {
       body: clientData
     });
     
-    const clientId = (createResponse as any).id;
+    const clientId = createResponse.data.id;
     createdClientIds.push(clientId);
 
     // Act - Get client using typed endpoint
@@ -76,9 +76,9 @@ describe('Client Management - CRUD with Typed NPM Packages', () => {
 
     // Assert
     expect(getResponse).toBeDefined();
-    expect((getResponse as any).id).toBe(clientId);
-    expect((getResponse as any).name).toBe(clientData.name);
-    expect((getResponse as any).email).toBe(clientData.email);
+    expect(getResponse.data.id).toBe(clientId);
+    expect(getResponse.data.name).toBe(clientData.name);
+    expect(getResponse.data.email).toBe(clientData.email);
   });
 
   test('should update client with typed client', async () => {
@@ -93,7 +93,7 @@ describe('Client Management - CRUD with Typed NPM Packages', () => {
       body: originalData
     });
     
-    const clientId = (createResponse as any).id;
+    const clientId = createResponse.data.id;
     createdClientIds.push(clientId);
 
     // Act - Update client
@@ -109,10 +109,10 @@ describe('Client Management - CRUD with Typed NPM Packages', () => {
 
     // Assert
     expect(updateResponse).toBeDefined();
-    expect((updateResponse as any).id).toBe(clientId);
-    expect((updateResponse as any).name).toBe(updateData.name);
-    expect((updateResponse as any).phone).toBe(updateData.phone);
-    expect((updateResponse as any).notes).toBe(updateData.notes);
+    expect(updateResponse.data.id).toBe(clientId);
+    expect(updateResponse.data.name).toBe(updateData.name);
+    expect(updateResponse.data.phone).toBe(updateData.phone);
+    expect(updateResponse.data.notes).toBe(updateData.notes);
   });
 
   test('should list clients with typed client', async () => {
@@ -128,10 +128,10 @@ describe('Client Management - CRUD with Typed NPM Packages', () => {
 
     // Assert - Response structure is typed
     expect(response).toBeDefined();
-    expect(Array.isArray((response as any).clients)).toBe(true);
-    expect((response as any).totalCount).toBeDefined();
-    expect((response as any).pageSize).toBeDefined();
-    expect((response as any).pageNumber).toBeDefined();
+    expect(Array.isArray(response.data.clients)).toBe(true);
+    expect(response.data.totalCount).toBeDefined();
+    expect(response.data.pageSize).toBeDefined();
+    expect(response.data.pageNumber).toBeDefined();
   });
 
   test('should create client group with typed client', async () => {
@@ -149,13 +149,13 @@ describe('Client Management - CRUD with Typed NPM Packages', () => {
       }
     });
     
-    createdClientIds.push((client1 as any).id, (client2 as any).id);
+    createdClientIds.push(client1.data.id, client2.data.id);
 
     // Act - Create client group
     const groupData = {
       name: `Test Group ${Date.now()}`,
       description: 'Created by typed API test',
-      clientIds: [(client1 as any).id, (client2 as any).id]
+      clientIds: [client1.data.id, client2.data.id]
     };
     
     const groupResponse = await client.clientManagement('/api/client-groups', 'post', {
@@ -164,11 +164,11 @@ describe('Client Management - CRUD with Typed NPM Packages', () => {
 
     // Assert
     expect(groupResponse).toBeDefined();
-    expect((groupResponse as any).id).toBeTruthy();
-    expect((groupResponse as any).name).toBe(groupData.name);
-    expect((groupResponse as any).description).toBe(groupData.description);
-    expect(Array.isArray((groupResponse as any).clients)).toBe(true);
-    expect((groupResponse as any).clients.length).toBe(2);
+    expect(groupResponse.data.id).toBeTruthy();
+    expect(groupResponse.data.name).toBe(groupData.name);
+    expect(groupResponse.data.description).toBe(groupData.description);
+    expect(Array.isArray(groupResponse.data.clients)).toBe(true);
+    expect(groupResponse.data.clients.length).toBe(2);
   });
 
   test('should handle user-client associations with typed client', async () => {
@@ -182,7 +182,7 @@ describe('Client Management - CRUD with Typed NPM Packages', () => {
       body: clientData
     });
     
-    const clientId = (clientResponse as any).id;
+    const clientId = clientResponse.data.id;
     createdClientIds.push(clientId);
 
     // Note: In a real test, you'd have a test user ID
@@ -215,7 +215,7 @@ describe('Client Management - CRUD with Typed NPM Packages', () => {
       body: clientData
     });
     
-    const clientId = (createResponse as any).id;
+    const clientId = createResponse.data.id;
 
     // Act - Delete client
     await client.clientManagement(`/api/clients/${clientId}`, 'delete');

--- a/tests/api/features/client-management/groups/happy-path/group-operations.api.spec.ts
+++ b/tests/api/features/client-management/groups/happy-path/group-operations.api.spec.ts
@@ -29,12 +29,13 @@ describe('Client Management - Group Operations', () => {
       body: groupData
     });
 
-    ctx.cleanup.addGroup((response as any).group_id);
+    const responseData = ctx.getData(response);
+    ctx.cleanup.addGroup(responseData.group_id);
 
     expect(response).toBeDefined();
-    expect((response as any).group_id).toBeTruthy();
-    expect((response as any).name).toBe(groupData.name);
-    expect((response as any).description).toBe(groupData.description);
+    expect(responseData.group_id).toBeTruthy();
+    expect(responseData.name).toBe(groupData.name);
+    expect(responseData.description).toBe(groupData.description);
   });
 
   test('should update an existing group', async () => {
@@ -47,20 +48,22 @@ describe('Client Management - Group Operations', () => {
     const created = await ctx.client.clientManagement('/api/groups', 'post', {
       body: groupData
     });
-    ctx.cleanup.addGroup((created as any).group_id);
+    const createdData = ctx.getData(created);
+    ctx.cleanup.addGroup(createdData.group_id);
 
     const updateData = {
       name: `UpdatedGroup_${Date.now()}`,
       description: 'Updated description'
     };
 
-    const response = await ctx.client.clientManagement(`/api/groups/${(created as any).group_id}`, 'put', {
+    const response = await ctx.client.clientManagement(`/api/groups/${createdData.group_id}`, 'put', {
       body: updateData
     });
 
-    expect((response as any).group_id).toBe((created as any).group_id);
-    expect((response as any).name).toBe(updateData.name);
-    expect((response as any).description).toBe(updateData.description);
+    const updateResponseData = ctx.getData(response);
+    expect(updateResponseData.group_id).toBe(createdData.group_id);
+    expect(updateResponseData.name).toBe(updateData.name);
+    expect(updateResponseData.description).toBe(updateData.description);
   });
 
   test('should delete a group', async () => {
@@ -73,10 +76,12 @@ describe('Client Management - Group Operations', () => {
     const created = await ctx.client.clientManagement('/api/groups', 'post', {
       body: groupData
     });
+    const deleteCreatedData = ctx.getData(created);
 
-    const response = await ctx.client.clientManagement(`/api/groups/${(created as any).group_id}`, 'delete');
+    const response = await ctx.client.clientManagement(`/api/groups/${deleteCreatedData.group_id}`, 'delete');
 
-    expect((response as any).success).toBe(true);
+    const deleteResponseData = ctx.getData(response);
+    expect(deleteResponseData.success).toBe(true);
   });
 
   test('should list all groups for a tenant', async () => {
@@ -88,7 +93,8 @@ describe('Client Management - Group Operations', () => {
         tenant_id: testTenantId
       }
     });
-    ctx.cleanup.addGroup((group1 as any).group_id);
+    const group1Data = ctx.getData(group1);
+    ctx.cleanup.addGroup(group1Data.group_id);
 
     const group2 = await ctx.client.clientManagement('/api/groups', 'post', {
       body: {
@@ -97,7 +103,8 @@ describe('Client Management - Group Operations', () => {
         tenant_id: testTenantId
       }
     });
-    ctx.cleanup.addGroup((group2 as any).group_id);
+    const group2Data = ctx.getData(group2);
+    ctx.cleanup.addGroup(group2Data.group_id);
 
     const response = await ctx.client.clientManagement('/api/groups', 'get', {
       params: {
@@ -109,9 +116,10 @@ describe('Client Management - Group Operations', () => {
       }
     });
 
-    expect((response as any).groups).toBeDefined();
-    expect(Array.isArray((response as any).groups)).toBe(true);
-    expect((response as any).groups.length).toBeGreaterThanOrEqual(2);
+    const listResponseData = ctx.getData(response);
+    expect(listResponseData.groups).toBeDefined();
+    expect(Array.isArray(listResponseData.groups)).toBe(true);
+    expect(listResponseData.groups.length).toBeGreaterThanOrEqual(2);
   });
 
   test('should add a client to a group', async () => {
@@ -123,22 +131,25 @@ describe('Client Management - Group Operations', () => {
         tenant_id: testTenantId
       }
     });
-    ctx.cleanup.addGroup((group as any).group_id);
+    const groupData = ctx.getData(group);
+    ctx.cleanup.addGroup(groupData.group_id);
 
     // Create a client
-    const clientData = TestDataFactory.client();
+    const clientRequestData = TestDataFactory.client();
     const client = await ctx.client.clientManagement('/api/clients', 'post', {
-      body: clientData
+      body: clientRequestData
     });
-    ctx.cleanup.addClient((client as any).client_id);
+    const clientData = ctx.getData(client);
+    ctx.cleanup.addClient(clientData.client_id);
 
     // Add client to group
     const response = await ctx.client.clientManagement(
-      `/api/groups/${(group as any).group_id}/clients/${(client as any).client_id}`,
+      `/api/groups/${groupData.group_id}/clients/${clientData.client_id}`,
       'post'
     );
 
-    expect((response as any).success).toBe(true);
+    const addClientResponseData = ctx.getData(response);
+    expect(addClientResponseData.success).toBe(true);
   });
 
   test('should remove a client from a group', async () => {
@@ -150,27 +161,30 @@ describe('Client Management - Group Operations', () => {
         tenant_id: testTenantId
       }
     });
-    ctx.cleanup.addGroup((group as any).group_id);
+    const removeGroupData = ctx.getData(group);
+    ctx.cleanup.addGroup(removeGroupData.group_id);
 
-    const clientData = TestDataFactory.client();
+    const removeClientRequestData = TestDataFactory.client();
     const client = await ctx.client.clientManagement('/api/clients', 'post', {
-      body: clientData
+      body: removeClientRequestData
     });
-    ctx.cleanup.addClient((client as any).client_id);
+    const removeClientResponseData = ctx.getData(client);
+    ctx.cleanup.addClient(removeClientResponseData.client_id);
 
     // Add client to group first
     await ctx.client.clientManagement(
-      `/api/groups/${(group as any).group_id}/clients/${(client as any).client_id}`,
+      `/api/groups/${removeGroupData.group_id}/clients/${removeClientResponseData.client_id}`,
       'post'
     );
 
     // Remove client from group
     const response = await ctx.client.clientManagement(
-      `/api/groups/${(group as any).group_id}/clients/${(client as any).client_id}`,
+      `/api/groups/${removeGroupData.group_id}/clients/${removeClientResponseData.client_id}`,
       'delete'
     );
 
-    expect((response as any).success).toBe(true);
+    const removeResponseData = ctx.getData(response);
+    expect(removeResponseData.success).toBe(true);
   });
 
   test('should get all clients in a group', async () => {
@@ -182,33 +196,36 @@ describe('Client Management - Group Operations', () => {
         tenant_id: testTenantId
       }
     });
-    ctx.cleanup.addGroup((group as any).group_id);
+    const listGroupData = ctx.getData(group);
+    ctx.cleanup.addGroup(listGroupData.group_id);
 
     // Create and add multiple clients
-    const client1Data = TestDataFactory.client();
+    const listClient1RequestData = TestDataFactory.client();
     const client1 = await ctx.client.clientManagement('/api/clients', 'post', {
-      body: client1Data
+      body: listClient1RequestData
     });
-    ctx.cleanup.addClient((client1 as any).client_id);
+    const client1ResponseData = ctx.getData(client1);
+    ctx.cleanup.addClient(client1ResponseData.client_id);
 
-    const client2Data = TestDataFactory.client();
+    const listClient2RequestData = TestDataFactory.client();
     const client2 = await ctx.client.clientManagement('/api/clients', 'post', {
-      body: client2Data
+      body: listClient2RequestData
     });
-    ctx.cleanup.addClient((client2 as any).client_id);
+    const client2ResponseData = ctx.getData(client2);
+    ctx.cleanup.addClient(client2ResponseData.client_id);
 
     await ctx.client.clientManagement(
-      `/api/groups/${(group as any).group_id}/clients/${(client1 as any).client_id}`,
+      `/api/groups/${listGroupData.group_id}/clients/${client1ResponseData.client_id}`,
       'post'
     );
     await ctx.client.clientManagement(
-      `/api/groups/${(group as any).group_id}/clients/${(client2 as any).client_id}`,
+      `/api/groups/${listGroupData.group_id}/clients/${client2ResponseData.client_id}`,
       'post'
     );
 
     // Get group clients
     const response = await ctx.client.clientManagement(
-      `/api/groups/${(group as any).group_id}/clients`,
+      `/api/groups/${listGroupData.group_id}/clients`,
       'get',
       {
         params: {
@@ -219,9 +236,10 @@ describe('Client Management - Group Operations', () => {
       }
     );
 
-    expect((response as any).clients).toBeDefined();
-    expect(Array.isArray((response as any).clients)).toBe(true);
-    expect((response as any).clients.length).toBe(2);
+    const groupClientsResponseData = ctx.getData(response);
+    expect(groupClientsResponseData.clients).toBeDefined();
+    expect(Array.isArray(groupClientsResponseData.clients)).toBe(true);
+    expect(groupClientsResponseData.clients.length).toBe(2);
   });
 
   test('should get all groups for a client', async () => {
@@ -230,7 +248,8 @@ describe('Client Management - Group Operations', () => {
     const client = await ctx.client.clientManagement('/api/clients', 'post', {
       body: clientData
     });
-    ctx.cleanup.addClient((client as any).client_id);
+    const clientGroupsClientData = ctx.getData(client);
+    ctx.cleanup.addClient(clientGroupsClientData.client_id);
 
     // Create and assign multiple groups
     const group1 = await ctx.client.clientManagement('/api/groups', 'post', {
@@ -240,7 +259,8 @@ describe('Client Management - Group Operations', () => {
         tenant_id: testTenantId
       }
     });
-    ctx.cleanup.addGroup((group1 as any).group_id);
+    const clientGroup1Data = ctx.getData(group1);
+    ctx.cleanup.addGroup(clientGroup1Data.group_id);
 
     const group2 = await ctx.client.clientManagement('/api/groups', 'post', {
       body: {
@@ -249,20 +269,21 @@ describe('Client Management - Group Operations', () => {
         tenant_id: testTenantId
       }
     });
-    ctx.cleanup.addGroup((group2 as any).group_id);
+    const clientGroup2Data = ctx.getData(group2);
+    ctx.cleanup.addGroup(clientGroup2Data.group_id);
 
     await ctx.client.clientManagement(
-      `/api/groups/${(group1 as any).group_id}/clients/${(client as any).client_id}`,
+      `/api/groups/${clientGroup1Data.group_id}/clients/${clientGroupsClientData.client_id}`,
       'post'
     );
     await ctx.client.clientManagement(
-      `/api/groups/${(group2 as any).group_id}/clients/${(client as any).client_id}`,
+      `/api/groups/${clientGroup2Data.group_id}/clients/${clientGroupsClientData.client_id}`,
       'post'
     );
 
     // Get client groups
     const response = await ctx.client.clientManagement(
-      `/api/clients/${(client as any).client_id}/groups`,
+      `/api/clients/${clientGroupsClientData.client_id}/groups`,
       'get',
       {
         params: {
@@ -273,8 +294,9 @@ describe('Client Management - Group Operations', () => {
       }
     );
 
-    expect((response as any).groups).toBeDefined();
-    expect(Array.isArray((response as any).groups)).toBe(true);
-    expect((response as any).groups.length).toBe(2);
+    const clientGroupsResponseData = ctx.getData(response);
+    expect(clientGroupsResponseData.groups).toBeDefined();
+    expect(Array.isArray(clientGroupsResponseData.groups)).toBe(true);
+    expect(clientGroupsResponseData.groups.length).toBe(2);
   });
 });

--- a/tests/api/features/client-management/user-associations/happy-path/user-client-associations.api.spec.ts
+++ b/tests/api/features/client-management/user-associations/happy-path/user-client-associations.api.spec.ts
@@ -24,7 +24,8 @@ describe('Client Management - User-Client Associations', () => {
     const client = await ctx.client.clientManagement('/api/clients', 'post', {
       body: clientData
     });
-    ctx.cleanup.addClient((client as any).client_id);
+    const clientResponseData = ctx.getData(client);
+    ctx.cleanup.addClient(clientResponseData.client_id);
 
     // Create a user
     const userData = TestDataFactory.user();
@@ -37,11 +38,12 @@ describe('Client Management - User-Client Associations', () => {
         role: 'User'
       }
     });
-    ctx.cleanup.addUser((user as any).userId);
+    const userResponseData = ctx.getData(user);
+    ctx.cleanup.addUser(userResponseData.userId);
 
     // Assign user to client
     const response = await ctx.client.clientManagement(
-      `/api/clients/${(client as any).client_id}/users/${(user as any).userId}`,
+      `/api/clients/${clientResponseData.client_id}/users/${userResponseData.userId}`,
       'post',
       {
         body: {
@@ -51,33 +53,36 @@ describe('Client Management - User-Client Associations', () => {
       }
     );
 
-    expect((response as any).success).toBe(true);
-    expect((response as any).association_id).toBeTruthy();
+    const assignResponseData = ctx.getData(response);
+    expect(assignResponseData.success).toBe(true);
+    expect(assignResponseData.association_id).toBeTruthy();
   });
 
   test('should remove a user from a client', async () => {
     // Create client and user
-    const clientData = TestDataFactory.client();
+    const removeClientData = TestDataFactory.client();
     const client = await ctx.client.clientManagement('/api/clients', 'post', {
-      body: clientData
+      body: removeClientData
     });
-    ctx.cleanup.addClient((client as any).client_id);
+    const removeClientResponseData = ctx.getData(client);
+    ctx.cleanup.addClient(removeClientResponseData.client_id);
 
-    const userData = TestDataFactory.user();
+    const removeUserData = TestDataFactory.user();
     const user = await ctx.client.identity('/api/users', 'post', {
       body: {
-        email: userData.email,
-        firstName: userData.firstName,
-        lastName: userData.lastName,
-        phoneNumber: userData.phoneNumber,
+        email: removeUserData.email,
+        firstName: removeUserData.firstName,
+        lastName: removeUserData.lastName,
+        phoneNumber: removeUserData.phoneNumber,
         role: 'User'
       }
     });
-    ctx.cleanup.addUser((user as any).userId);
+    const removeUserResponseData = ctx.getData(user);
+    ctx.cleanup.addUser(removeUserResponseData.userId);
 
     // Assign user to client first
     await ctx.client.clientManagement(
-      `/api/clients/${(client as any).client_id}/users/${(user as any).userId}`,
+      `/api/clients/${removeClientResponseData.client_id}/users/${removeUserResponseData.userId}`,
       'post',
       {
         body: {
@@ -89,7 +94,7 @@ describe('Client Management - User-Client Associations', () => {
 
     // Remove user from client
     const response = await ctx.client.clientManagement(
-      `/api/clients/${(client as any).client_id}/users/${(user as any).userId}`,
+      `/api/clients/${removeClientResponseData.client_id}/users/${removeUserResponseData.userId}`,
       'delete',
       {
         body: {
@@ -98,45 +103,49 @@ describe('Client Management - User-Client Associations', () => {
       }
     );
 
-    expect((response as any).success).toBe(true);
+    const removeAssociationResponseData = ctx.getData(response);
+    expect(removeAssociationResponseData.success).toBe(true);
   });
 
   test('should get all users assigned to a client', async () => {
     // Create a client
-    const clientData = TestDataFactory.client();
+    const listUsersClientData = TestDataFactory.client();
     const client = await ctx.client.clientManagement('/api/clients', 'post', {
-      body: clientData
+      body: listUsersClientData
     });
-    ctx.cleanup.addClient((client as any).client_id);
+    const listUsersClientResponseData = ctx.getData(client);
+    ctx.cleanup.addClient(listUsersClientResponseData.client_id);
 
     // Create and assign multiple users
-    const user1Data = TestDataFactory.user();
+    const listUser1Data = TestDataFactory.user();
     const user1 = await ctx.client.identity('/api/users', 'post', {
       body: {
-        email: user1Data.email,
-        firstName: user1Data.firstName,
-        lastName: user1Data.lastName,
-        phoneNumber: user1Data.phoneNumber,
+        email: listUser1Data.email,
+        firstName: listUser1Data.firstName,
+        lastName: listUser1Data.lastName,
+        phoneNumber: listUser1Data.phoneNumber,
         role: 'User'
       }
     });
-    ctx.cleanup.addUser((user1 as any).userId);
+    const listUser1ResponseData = ctx.getData(user1);
+    ctx.cleanup.addUser(listUser1ResponseData.userId);
 
-    const user2Data = TestDataFactory.user();
+    const listUser2Data = TestDataFactory.user();
     const user2 = await ctx.client.identity('/api/users', 'post', {
       body: {
-        email: user2Data.email,
-        firstName: user2Data.firstName,
-        lastName: user2Data.lastName,
-        phoneNumber: user2Data.phoneNumber,
+        email: listUser2Data.email,
+        firstName: listUser2Data.firstName,
+        lastName: listUser2Data.lastName,
+        phoneNumber: listUser2Data.phoneNumber,
         role: 'User'
       }
     });
-    ctx.cleanup.addUser((user2 as any).userId);
+    const listUser2ResponseData = ctx.getData(user2);
+    ctx.cleanup.addUser(listUser2ResponseData.userId);
 
     // Assign both users to the client
     await ctx.client.clientManagement(
-      `/api/clients/${(client as any).client_id}/users/${(user1 as any).userId}`,
+      `/api/clients/${listUsersClientResponseData.client_id}/users/${listUser1ResponseData.userId}`,
       'post',
       {
         body: {
@@ -147,7 +156,7 @@ describe('Client Management - User-Client Associations', () => {
     );
 
     await ctx.client.clientManagement(
-      `/api/clients/${(client as any).client_id}/users/${(user2 as any).userId}`,
+      `/api/clients/${listUsersClientResponseData.client_id}/users/${listUser2ResponseData.userId}`,
       'post',
       {
         body: {
@@ -159,7 +168,7 @@ describe('Client Management - User-Client Associations', () => {
 
     // Get client users
     const response = await ctx.client.clientManagement(
-      `/api/clients/${(client as any).client_id}/users`,
+      `/api/clients/${listUsersClientResponseData.client_id}/users`,
       'get',
       {
         params: {
@@ -172,42 +181,46 @@ describe('Client Management - User-Client Associations', () => {
       }
     );
 
-    expect((response as any).users).toBeDefined();
-    expect(Array.isArray((response as any).users)).toBe(true);
-    expect((response as any).users.length).toBe(2);
-    expect((response as any).total_count).toBe(2);
+    const clientUsersResponseData = ctx.getData(response);
+    expect(clientUsersResponseData.users).toBeDefined();
+    expect(Array.isArray(clientUsersResponseData.users)).toBe(true);
+    expect(clientUsersResponseData.users.length).toBe(2);
+    expect(clientUsersResponseData.total_count).toBe(2);
   });
 
   test('should get all clients assigned to a user', async () => {
     // Create a user
-    const userData = TestDataFactory.user();
+    const userClientsUserData = TestDataFactory.user();
     const user = await ctx.client.identity('/api/users', 'post', {
       body: {
-        email: userData.email,
-        firstName: userData.firstName,
-        lastName: userData.lastName,
-        phoneNumber: userData.phoneNumber,
+        email: userClientsUserData.email,
+        firstName: userClientsUserData.firstName,
+        lastName: userClientsUserData.lastName,
+        phoneNumber: userClientsUserData.phoneNumber,
         role: 'User'
       }
     });
-    ctx.cleanup.addUser((user as any).userId);
+    const userClientsUserResponseData = ctx.getData(user);
+    ctx.cleanup.addUser(userClientsUserResponseData.userId);
 
     // Create and assign multiple clients
-    const client1Data = TestDataFactory.client();
+    const userClient1Data = TestDataFactory.client();
     const client1 = await ctx.client.clientManagement('/api/clients', 'post', {
-      body: client1Data
+      body: userClient1Data
     });
-    ctx.cleanup.addClient((client1 as any).client_id);
+    const userClient1ResponseData = ctx.getData(client1);
+    ctx.cleanup.addClient(userClient1ResponseData.client_id);
 
-    const client2Data = TestDataFactory.client();
+    const userClient2Data = TestDataFactory.client();
     const client2 = await ctx.client.clientManagement('/api/clients', 'post', {
-      body: client2Data
+      body: userClient2Data
     });
-    ctx.cleanup.addClient((client2 as any).client_id);
+    const userClient2ResponseData = ctx.getData(client2);
+    ctx.cleanup.addClient(userClient2ResponseData.client_id);
 
     // Assign user to both clients
     await ctx.client.clientManagement(
-      `/api/clients/${(client1 as any).client_id}/users/${(user as any).userId}`,
+      `/api/clients/${userClient1ResponseData.client_id}/users/${userClientsUserResponseData.userId}`,
       'post',
       {
         body: {
@@ -218,7 +231,7 @@ describe('Client Management - User-Client Associations', () => {
     );
 
     await ctx.client.clientManagement(
-      `/api/clients/${(client2 as any).client_id}/users/${(user as any).userId}`,
+      `/api/clients/${userClient2ResponseData.client_id}/users/${userClientsUserResponseData.userId}`,
       'post',
       {
         body: {
@@ -230,7 +243,7 @@ describe('Client Management - User-Client Associations', () => {
 
     // Get user clients
     const response = await ctx.client.clientManagement(
-      `/api/users/${(user as any).userId}/clients`,
+      `/api/users/${userClientsUserResponseData.userId}/clients`,
       'get',
       {
         params: {
@@ -243,39 +256,42 @@ describe('Client Management - User-Client Associations', () => {
       }
     );
 
-    expect((response as any).clients).toBeDefined();
-    expect(Array.isArray((response as any).clients)).toBe(true);
-    expect((response as any).clients.length).toBe(2);
-    expect((response as any).total_count).toBe(2);
+    const userClientsResponseData = ctx.getData(response);
+    expect(userClientsResponseData.clients).toBeDefined();
+    expect(Array.isArray(userClientsResponseData.clients)).toBe(true);
+    expect(userClientsResponseData.clients.length).toBe(2);
+    expect(userClientsResponseData.total_count).toBe(2);
   });
 
   test('should handle pagination for user-client associations', async () => {
     // Create a client
-    const clientData = TestDataFactory.client();
+    const paginationClientData = TestDataFactory.client();
     const client = await ctx.client.clientManagement('/api/clients', 'post', {
-      body: clientData
+      body: paginationClientData
     });
-    ctx.cleanup.addClient((client as any).client_id);
+    const paginationClientResponseData = ctx.getData(client);
+    ctx.cleanup.addClient(paginationClientResponseData.client_id);
 
     // Create multiple users (more than page size)
     const users = [];
     for (let i = 0; i < 5; i++) {
-      const userData = TestDataFactory.user();
+      const paginationUserData = TestDataFactory.user();
       const user = await ctx.client.identity('/api/users', 'post', {
         body: {
-          email: userData.email,
-          firstName: userData.firstName,
-          lastName: userData.lastName,
-          phoneNumber: userData.phoneNumber,
+          email: paginationUserData.email,
+          firstName: paginationUserData.firstName,
+          lastName: paginationUserData.lastName,
+          phoneNumber: paginationUserData.phoneNumber,
           role: 'User'
         }
       });
-      users.push(user);
-      ctx.cleanup.addUser((user as any).userId);
+      const paginationUserResponseData = ctx.getData(user);
+      users.push(paginationUserResponseData);
+      ctx.cleanup.addUser(paginationUserResponseData.userId);
 
       // Assign user to client
       await ctx.client.clientManagement(
-        `/api/clients/${(client as any).client_id}/users/${(user as any).userId}`,
+        `/api/clients/${paginationClientResponseData.client_id}/users/${paginationUserResponseData.userId}`,
         'post',
         {
           body: {
@@ -288,7 +304,7 @@ describe('Client Management - User-Client Associations', () => {
 
     // Get first page
     const page1 = await ctx.client.clientManagement(
-      `/api/clients/${(client as any).client_id}/users`,
+      `/api/clients/${paginationClientResponseData.client_id}/users`,
       'get',
       {
         params: {
@@ -301,14 +317,15 @@ describe('Client Management - User-Client Associations', () => {
       }
     );
 
-    expect((page1 as any).users.length).toBe(3);
-    expect((page1 as any).total_count).toBe(5);
-    expect((page1 as any).page).toBe(1);
-    expect((page1 as any).page_size).toBe(3);
+    const page1ResponseData = ctx.getData(page1);
+    expect(page1ResponseData.users.length).toBe(3);
+    expect(page1ResponseData.total_count).toBe(5);
+    expect(page1ResponseData.page).toBe(1);
+    expect(page1ResponseData.page_size).toBe(3);
 
     // Get second page
     const page2 = await ctx.client.clientManagement(
-      `/api/clients/${(client as any).client_id}/users`,
+      `/api/clients/${paginationClientResponseData.client_id}/users`,
       'get',
       {
         params: {
@@ -321,34 +338,37 @@ describe('Client Management - User-Client Associations', () => {
       }
     );
 
-    expect((page2 as any).users.length).toBe(2);
-    expect((page2 as any).page).toBe(2);
+    const page2ResponseData = ctx.getData(page2);
+    expect(page2ResponseData.users.length).toBe(2);
+    expect(page2ResponseData.page).toBe(2);
   });
 
   test('should track assignment metadata', async () => {
     // Create client and user
-    const clientData = TestDataFactory.client();
+    const metadataClientData = TestDataFactory.client();
     const client = await ctx.client.clientManagement('/api/clients', 'post', {
-      body: clientData
+      body: metadataClientData
     });
-    ctx.cleanup.addClient((client as any).client_id);
+    const metadataClientResponseData = ctx.getData(client);
+    ctx.cleanup.addClient(metadataClientResponseData.client_id);
 
-    const userData = TestDataFactory.user();
+    const metadataUserData = TestDataFactory.user();
     const user = await ctx.client.identity('/api/users', 'post', {
       body: {
-        email: userData.email,
-        firstName: userData.firstName,
-        lastName: userData.lastName,
-        phoneNumber: userData.phoneNumber,
+        email: metadataUserData.email,
+        firstName: metadataUserData.firstName,
+        lastName: metadataUserData.lastName,
+        phoneNumber: metadataUserData.phoneNumber,
         role: 'User'
       }
     });
-    ctx.cleanup.addUser((user as any).userId);
+    const metadataUserResponseData = ctx.getData(user);
+    ctx.cleanup.addUser(metadataUserResponseData.userId);
 
     // Assign with metadata
     const assignedBy = 'admin-user-123';
     await ctx.client.clientManagement(
-      `/api/clients/${(client as any).client_id}/users/${(user as any).userId}`,
+      `/api/clients/${metadataClientResponseData.client_id}/users/${metadataUserResponseData.userId}`,
       'post',
       {
         body: {
@@ -360,7 +380,7 @@ describe('Client Management - User-Client Associations', () => {
 
     // Get client users and verify metadata
     const response = await ctx.client.clientManagement(
-      `/api/clients/${(client as any).client_id}/users`,
+      `/api/clients/${metadataClientResponseData.client_id}/users`,
       'get',
       {
         params: {
@@ -371,7 +391,8 @@ describe('Client Management - User-Client Associations', () => {
       }
     );
 
-    const assignedUser = (response as any).users[0];
+    const metadataResponseData = ctx.getData(response);
+    const assignedUser = metadataResponseData.users[0];
     expect(assignedUser.assigned_by).toBe(assignedBy);
     expect(assignedUser.assigned_at).toBeTruthy();
   });

--- a/tests/api/features/identity/audit-logs/happy-path/audit-operations.api.spec.ts
+++ b/tests/api/features/identity/audit-logs/happy-path/audit-operations.api.spec.ts
@@ -26,9 +26,10 @@ describe('Identity Service - Audit Log Operations', () => {
     });
 
     expect(response).toBeDefined();
-    expect((response as any).logs).toBeDefined();
-    expect(Array.isArray((response as any).logs)).toBe(true);
-    expect((response as any).totalCount).toBeDefined();
+    const auditLogsData = ctx.getData(response);
+    expect(auditLogsData.logs).toBeDefined();
+    expect(Array.isArray(auditLogsData.logs)).toBe(true);
+    expect(auditLogsData.totalCount).toBeDefined();
   });
 
   test('should filter audit logs by user', async () => {
@@ -43,7 +44,8 @@ describe('Identity Service - Audit Log Operations', () => {
     });
 
     expect(response).toBeDefined();
-    expect((response as any).logs).toBeDefined();
+    const userFilterData = ctx.getData(response);
+    expect(userFilterData.logs).toBeDefined();
   });
 
   test('should filter audit logs by date range', async () => {
@@ -59,7 +61,8 @@ describe('Identity Service - Audit Log Operations', () => {
     });
 
     expect(response).toBeDefined();
-    expect((response as any).logs).toBeDefined();
+    const dateFilterData = ctx.getData(response);
+    expect(dateFilterData.logs).toBeDefined();
   });
 
   test('should filter audit logs by action type', async () => {
@@ -74,9 +77,10 @@ describe('Identity Service - Audit Log Operations', () => {
     });
 
     expect(response).toBeDefined();
-    expect((response as any).logs).toBeDefined();
-    if ((response as any).logs.length > 0) {
-      expect((response as any).logs[0].actionType).toBe('LOGIN');
+    const actionFilterData = ctx.getData(response);
+    expect(actionFilterData.logs).toBeDefined();
+    if (actionFilterData.logs.length > 0) {
+      expect(actionFilterData.logs[0].actionType).toBe('LOGIN');
     }
   });
 
@@ -86,12 +90,14 @@ describe('Identity Service - Audit Log Operations', () => {
       params: { query: { pageNumber: 1, pageSize: 1 } }
     });
 
-    if ((logsResponse as any).logs.length > 0) {
-      const logId = (logsResponse as any).logs[0].id;
+    const logsData = ctx.getData(logsResponse);
+    if (logsData.logs.length > 0) {
+      const logId = logsData.logs[0].id;
       const response = await ctx.client.identity(`/api/audit-logs/${logId}`, 'get');
+      const logByIdData = ctx.getData(response);
 
       expect(response).toBeDefined();
-      expect((response as any).id).toBe(logId);
+      expect(logByIdData.id).toBe(logId);
     }
   });
 
@@ -105,6 +111,7 @@ describe('Identity Service - Audit Log Operations', () => {
     });
 
     expect(response).toBeDefined();
-    expect((response as any).downloadUrl).toBeTruthy();
+    const exportData = ctx.getData(response);
+    expect(exportData.downloadUrl).toBeTruthy();
   });
 });

--- a/tests/api/features/identity/authentication/happy-path/typed-login.api.spec.ts
+++ b/tests/api/features/identity/authentication/happy-path/typed-login.api.spec.ts
@@ -40,9 +40,10 @@ describe('Business Feature: Platform Access Control', () => {
 
     // Assert - Response is fully typed based on the OpenAPI schema
     expect(response).toBeDefined();
-    expect((response as any).success).toBe(true);
-    expect((response as any).tokenInfo).toBeDefined();
-    expect((response as any).tokenInfo.accessToken).toBeTruthy();
+    const loginResponseData = ctx.getData(response);
+    expect(loginResponseData.success).toBe(true);
+    expect(loginResponseData.tokenInfo).toBeDefined();
+    expect(loginResponseData.tokenInfo.accessToken).toBeTruthy();
     
     // Verify token was set
     expect(ctx.client.getAuthToken()).toBeTruthy();
@@ -57,8 +58,9 @@ describe('Business Feature: Platform Access Control', () => {
 
     // Assert
     expect(response).toBeDefined();
-    expect((response as any).email).toBe(superAdminCredentials.email);
-    expect((response as any).roles).toBeDefined();
+    const meResponseData = ctx.getData(response);
+    expect(meResponseData.email).toBe(superAdminCredentials.email);
+    expect(meResponseData.roles).toBeDefined();
   });
 
   test('should refresh token with typed ctx.client', async () => {
@@ -67,7 +69,8 @@ describe('Business Feature: Platform Access Control', () => {
       superAdminCredentials.email,
       superAdminCredentials.password
     );
-    const refreshToken = (loginResponse as any).tokenInfo?.refreshToken;
+    const loginTokenData = ctx.getData(loginResponse);
+    const refreshToken = loginTokenData.tokenInfo?.refreshToken;
     expect(refreshToken).toBeTruthy();
 
     // Act - Refresh token
@@ -77,9 +80,10 @@ describe('Business Feature: Platform Access Control', () => {
 
     // Assert
     expect(refreshResponse).toBeDefined();
-    expect((refreshResponse as any).tokenInfo?.accessToken).toBeTruthy();
-    expect((refreshResponse as any).tokenInfo?.accessToken).not.toBe(
-      (loginResponse as any).tokenInfo?.accessToken
+    const refreshTokenData = ctx.getData(refreshResponse);
+    expect(refreshTokenData.tokenInfo?.accessToken).toBeTruthy();
+    expect(refreshTokenData.tokenInfo?.accessToken).not.toBe(
+      loginTokenData.tokenInfo?.accessToken
     );
   });
 

--- a/tests/api/features/identity/invitations/happy-path/invitation-operations.api.spec.ts
+++ b/tests/api/features/identity/invitations/happy-path/invitation-operations.api.spec.ts
@@ -28,14 +28,15 @@ describe('Identity Service - Invitation Operations', () => {
     const response = await ctx.client.identity('/api/invitations', 'post', {
       body: invitationData
     });
+    const responseData = ctx.getData(response);
 
-    ctx.cleanup.addInvitation((response as any).invitationId);
+    ctx.cleanup.addInvitation(responseData.invitationId);
 
     expect(response).toBeDefined();
-    expect((response as any).invitationId).toBeTruthy();
-    expect((response as any).email).toBe(invitationData.email);
-    expect((response as any).status).toBe('Pending');
-    expect((response as any).invitationToken).toBeTruthy();
+    expect(responseData.invitationId).toBeTruthy();
+    expect(responseData.email).toBe(invitationData.email);
+    expect(responseData.status).toBe('Pending');
+    expect(responseData.invitationToken).toBeTruthy();
   });
 
   test('should get invitation by ID', async () => {
@@ -49,12 +50,14 @@ describe('Identity Service - Invitation Operations', () => {
     const created = await ctx.client.identity('/api/invitations', 'post', {
       body: invitationData
     });
-    ctx.cleanup.addInvitation((created as any).invitationId);
+    const createdData = ctx.getData(created);
+    ctx.cleanup.addInvitation(createdData.invitationId);
 
-    const response = await ctx.client.identity(`/api/invitations/${(created as any).invitationId}`, 'get');
+    const response = await ctx.client.identity(`/api/invitations/${createdData.invitationId}`, 'get');
+    const responseData = ctx.getData(response);
 
-    expect((response as any).invitationId).toBe((created as any).invitationId);
-    expect((response as any).email).toBe(invitationData.email);
+    expect(responseData.invitationId).toBe(createdData.invitationId);
+    expect(responseData.email).toBe(invitationData.email);
   });
 
   test('should accept invitation', async () => {
@@ -68,18 +71,20 @@ describe('Identity Service - Invitation Operations', () => {
     const created = await ctx.client.identity('/api/invitations', 'post', {
       body: invitationData
     });
-    ctx.cleanup.addInvitation((created as any).invitationId);
+    const createdData = ctx.getData(created);
+    ctx.cleanup.addInvitation(createdData.invitationId);
 
-    const response = await ctx.client.identity(`/api/invitations/${(created as any).invitationId}/accept`, 'post', {
+    const response = await ctx.client.identity(`/api/invitations/${createdData.invitationId}/accept`, 'post', {
       body: {
-        invitationToken: (created as any).invitationToken,
+        invitationToken: createdData.invitationToken,
         password: 'NewUser123!@#'
       }
     });
+    const responseData = ctx.getData(response);
 
-    expect((response as any).success).toBe(true);
-    expect((response as any).userId).toBeTruthy();
-    ctx.cleanup.addUser((response as any).userId);
+    expect(responseData.success).toBe(true);
+    expect(responseData.userId).toBeTruthy();
+    ctx.cleanup.addUser(responseData.userId);
   });
 
   test('should resend invitation', async () => {
@@ -93,12 +98,14 @@ describe('Identity Service - Invitation Operations', () => {
     const created = await ctx.client.identity('/api/invitations', 'post', {
       body: invitationData
     });
-    ctx.cleanup.addInvitation((created as any).invitationId);
+    const createdData = ctx.getData(created);
+    ctx.cleanup.addInvitation(createdData.invitationId);
 
-    const response = await ctx.client.identity(`/api/invitations/${(created as any).invitationId}/resend`, 'post');
+    const response = await ctx.client.identity(`/api/invitations/${createdData.invitationId}/resend`, 'post');
+    const responseData = ctx.getData(response);
 
-    expect((response as any).success).toBe(true);
-    expect((response as any).message).toContain('resent');
+    expect(responseData.success).toBe(true);
+    expect(responseData.message).toContain('resent');
   });
 
   test('should cancel invitation', async () => {
@@ -112,13 +119,16 @@ describe('Identity Service - Invitation Operations', () => {
     const created = await ctx.client.identity('/api/invitations', 'post', {
       body: invitationData
     });
+    const createdData = ctx.getData(created);
 
-    const response = await ctx.client.identity(`/api/invitations/${(created as any).invitationId}/cancel`, 'post');
+    const response = await ctx.client.identity(`/api/invitations/${createdData.invitationId}/cancel`, 'post');
+    const responseData = ctx.getData(response);
 
-    expect((response as any).success).toBe(true);
+    expect(responseData.success).toBe(true);
 
-    const getResponse = await ctx.client.identity(`/api/invitations/${(created as any).invitationId}`, 'get');
-    expect((getResponse as any).status).toBe('Cancelled');
+    const getResponse = await ctx.client.identity(`/api/invitations/${createdData.invitationId}`, 'get');
+    const getResponseData = ctx.getData(getResponse);
+    expect(getResponseData.status).toBe('Cancelled');
   });
 
   test('should list pending invitations', async () => {
@@ -131,9 +141,10 @@ describe('Identity Service - Invitation Operations', () => {
         } 
       }
     });
+    const responseData = ctx.getData(response);
 
-    expect((response as any).invitations).toBeDefined();
-    expect(Array.isArray((response as any).invitations)).toBe(true);
+    expect(responseData.invitations).toBeDefined();
+    expect(Array.isArray(responseData.invitations)).toBe(true);
   });
 
   test('should validate invitation token', async () => {
@@ -147,15 +158,17 @@ describe('Identity Service - Invitation Operations', () => {
     const created = await ctx.client.identity('/api/invitations', 'post', {
       body: invitationData
     });
-    ctx.cleanup.addInvitation((created as any).invitationId);
+    const createdData = ctx.getData(created);
+    ctx.cleanup.addInvitation(createdData.invitationId);
 
     const response = await ctx.client.identity('/api/invitations/validate', 'post', {
       body: {
-        invitationToken: (created as any).invitationToken
+        invitationToken: createdData.invitationToken
       }
     });
+    const responseData = ctx.getData(response);
 
-    expect((response as any).valid).toBe(true);
-    expect((response as any).invitationId).toBe((created as any).invitationId);
+    expect(responseData.valid).toBe(true);
+    expect(responseData.invitationId).toBe(createdData.invitationId);
   });
 });

--- a/tests/api/features/identity/password-reset/happy-path/password-reset.api.spec.ts
+++ b/tests/api/features/identity/password-reset/happy-path/password-reset.api.spec.ts
@@ -26,7 +26,8 @@ describe('Identity Service - Password Reset Operations', () => {
         password: 'OldPassword123!'
       }
     });
-    testUserId = (user as any).userId;
+    const userPasswordData = ctx.getData(user);
+    testUserId = userPasswordData.userId;
     ctx.cleanup.addUser(testUserId);
   });
 
@@ -42,8 +43,9 @@ describe('Identity Service - Password Reset Operations', () => {
     });
 
     expect(response).toBeDefined();
-    expect((response as any).success).toBe(true);
-    expect((response as any).message).toContain('reset email sent');
+    const resetRequestData = ctx.getData(response);
+    expect(resetRequestData.success).toBe(true);
+    expect(resetRequestData.message).toContain('reset email sent');
   });
 
   test('should validate password reset token', async () => {
@@ -64,7 +66,8 @@ describe('Identity Service - Password Reset Operations', () => {
     });
 
     expect(response).toBeDefined();
-    expect((response as any).valid).toBeDefined();
+    const validateData = ctx.getData(response);
+    expect(validateData.valid).toBeDefined();
   });
 
   test('should reset password with valid token', async () => {
@@ -86,8 +89,9 @@ describe('Identity Service - Password Reset Operations', () => {
     });
 
     expect(response).toBeDefined();
-    expect((response as any).success).toBe(true);
-    expect((response as any).message).toContain('Password reset successful');
+    const confirmResetData = ctx.getData(response);
+    expect(confirmResetData.success).toBe(true);
+    expect(confirmResetData.message).toContain('Password reset successful');
   });
 
   test('should change password for authenticated user', async () => {
@@ -99,7 +103,8 @@ describe('Identity Service - Password Reset Operations', () => {
     });
 
     expect(response).toBeDefined();
-    expect((response as any).success).toBe(true);
+    const changePasswordData = ctx.getData(response);
+    expect(changePasswordData.success).toBe(true);
   });
 
   test('should enforce password policy', async () => {
@@ -122,11 +127,12 @@ describe('Identity Service - Password Reset Operations', () => {
     const response = await ctx.client.identity('/api/auth/password-policy', 'get');
 
     expect(response).toBeDefined();
-    expect((response as any).minLength).toBeDefined();
-    expect((response as any).requireUppercase).toBeDefined();
-    expect((response as any).requireLowercase).toBeDefined();
-    expect((response as any).requireNumbers).toBeDefined();
-    expect((response as any).requireSpecialCharacters).toBeDefined();
+    const policyData = ctx.getData(response);
+    expect(policyData.minLength).toBeDefined();
+    expect(policyData.requireUppercase).toBeDefined();
+    expect(policyData.requireLowercase).toBeDefined();
+    expect(policyData.requireNumbers).toBeDefined();
+    expect(policyData.requireSpecialCharacters).toBeDefined();
   });
 
   test('should check password strength', async () => {
@@ -137,9 +143,10 @@ describe('Identity Service - Password Reset Operations', () => {
     });
 
     expect(response).toBeDefined();
-    expect((response as any).strength).toBeDefined();
-    expect((response as any).score).toBeDefined();
-    expect((response as any).suggestions).toBeDefined();
+    const strengthData = ctx.getData(response);
+    expect(strengthData.strength).toBeDefined();
+    expect(strengthData.score).toBeDefined();
+    expect(strengthData.suggestions).toBeDefined();
   });
 
   test('should expire password reset token after use', async () => {

--- a/tests/api/features/identity/permission-management/happy-path/permission-crud.api.spec.ts
+++ b/tests/api/features/identity/permission-management/happy-path/permission-crud.api.spec.ts
@@ -27,14 +27,15 @@ describe('Identity Service - Permission Management Operations', () => {
       body: permissionData
     });
 
-    ctx.cleanup.addPermission((response as any).permissionId);
+    const createdPermissionData = ctx.getData(response);
+    ctx.cleanup.addPermission(createdPermissionData.permissionId);
 
     expect(response).toBeDefined();
-    expect((response as any).permissionId).toBeTruthy();
-    expect((response as any).name).toBe(permissionData.name);
-    expect((response as any).description).toBe(permissionData.description);
-    expect((response as any).resource).toBe(permissionData.resource);
-    expect((response as any).action).toBe(permissionData.action);
+    expect(createdPermissionData.permissionId).toBeTruthy();
+    expect(createdPermissionData.name).toBe(permissionData.name);
+    expect(createdPermissionData.description).toBe(permissionData.description);
+    expect(createdPermissionData.resource).toBe(permissionData.resource);
+    expect(createdPermissionData.action).toBe(permissionData.action);
   });
 
   test('should retrieve permission by ID', async () => {
@@ -48,13 +49,15 @@ describe('Identity Service - Permission Management Operations', () => {
     const created = await ctx.client.identity('/api/permissions', 'post', {
       body: permissionData
     });
-    ctx.cleanup.addPermission((created as any).permissionId);
+    const createdRetrievalData = ctx.getData(created);
+    ctx.cleanup.addPermission(createdRetrievalData.permissionId);
 
-    const retrieved = await ctx.client.identity(`/api/permissions/${(created as any).permissionId}`, 'get');
+    const retrieved = await ctx.client.identity(`/api/permissions/${createdRetrievalData.permissionId}`, 'get');
+    const retrievedData = ctx.getData(retrieved);
 
-    expect((retrieved as any).permissionId).toBe((created as any).permissionId);
-    expect((retrieved as any).name).toBe(permissionData.name);
-    expect((retrieved as any).description).toBe(permissionData.description);
+    expect(retrievedData.permissionId).toBe(createdRetrievalData.permissionId);
+    expect(retrievedData.name).toBe(permissionData.name);
+    expect(retrievedData.description).toBe(permissionData.description);
   });
 
   test('should update permission', async () => {
@@ -68,20 +71,22 @@ describe('Identity Service - Permission Management Operations', () => {
     const created = await ctx.client.identity('/api/permissions', 'post', {
       body: permissionData
     });
-    ctx.cleanup.addPermission((created as any).permissionId);
+    const createdUpdateData = ctx.getData(created);
+    ctx.cleanup.addPermission(createdUpdateData.permissionId);
 
     const updateData = {
       description: 'Updated permission description',
       action: 'write'
     };
 
-    const updated = await ctx.client.identity(`/api/permissions/${(created as any).permissionId}`, 'put', {
+    const updated = await ctx.client.identity(`/api/permissions/${createdUpdateData.permissionId}`, 'put', {
       body: updateData
     });
+    const updatedData = ctx.getData(updated);
 
-    expect((updated as any).permissionId).toBe((created as any).permissionId);
-    expect((updated as any).description).toBe(updateData.description);
-    expect((updated as any).action).toBe(updateData.action);
+    expect(updatedData.permissionId).toBe(createdUpdateData.permissionId);
+    expect(updatedData.description).toBe(updateData.description);
+    expect(updatedData.action).toBe(updateData.action);
   });
 
   test('should delete permission', async () => {
@@ -96,12 +101,14 @@ describe('Identity Service - Permission Management Operations', () => {
       body: permissionData
     });
 
-    const deleteResponse = await ctx.client.identity(`/api/permissions/${(created as any).permissionId}`, 'delete');
+    const createdDeleteData = ctx.getData(created);
+    const deleteResponse = await ctx.client.identity(`/api/permissions/${createdDeleteData.permissionId}`, 'delete');
+    const deleteResponseData = ctx.getData(deleteResponse);
     
-    expect((deleteResponse as any).success).toBe(true);
+    expect(deleteResponseData.success).toBe(true);
 
     await expect(
-      ctx.client.identity(`/api/permissions/${(created as any).permissionId}`, 'get')
+      ctx.client.identity(`/api/permissions/${createdDeleteData.permissionId}`, 'get')
     ).rejects.toMatchObject({
       response: { status: 404 }
     });
@@ -125,12 +132,14 @@ describe('Identity Service - Permission Management Operations', () => {
     const created1 = await ctx.client.identity('/api/permissions', 'post', {
       body: permission1
     });
-    ctx.cleanup.addPermission((created1 as any).permissionId);
+    const created1Data = ctx.getData(created1);
+    ctx.cleanup.addPermission(created1Data.permissionId);
 
     const created2 = await ctx.client.identity('/api/permissions', 'post', {
       body: permission2
     });
-    ctx.cleanup.addPermission((created2 as any).permissionId);
+    const created2Data = ctx.getData(created2);
+    ctx.cleanup.addPermission(created2Data.permissionId);
 
     const response = await ctx.client.identity('/api/permissions', 'get', {
       params: { 
@@ -141,12 +150,13 @@ describe('Identity Service - Permission Management Operations', () => {
       }
     });
 
-    expect((response as any).permissions).toBeDefined();
-    expect(Array.isArray((response as any).permissions)).toBe(true);
+    const listResponseData = ctx.getData(response);
+    expect(listResponseData.permissions).toBeDefined();
+    expect(Array.isArray(listResponseData.permissions)).toBe(true);
     
-    const permissionIds = (response as any).permissions.map((p: any) => p.permissionId);
-    expect(permissionIds).toContain((created1 as any).permissionId);
-    expect(permissionIds).toContain((created2 as any).permissionId);
+    const permissionIds = listResponseData.permissions.map((p: any) => p.permissionId);
+    expect(permissionIds).toContain(created1Data.permissionId);
+    expect(permissionIds).toContain(created2Data.permissionId);
   });
 
   test('should grant permission to user', async () => {
@@ -160,7 +170,8 @@ describe('Identity Service - Permission Management Operations', () => {
     const permission = await ctx.client.identity('/api/permissions', 'post', {
       body: permissionData
     });
-    ctx.cleanup.addPermission((permission as any).permissionId);
+    const permissionGrantData = ctx.getData(permission);
+    ctx.cleanup.addPermission(permissionGrantData.permissionId);
 
     const userData = {
       email: `test.user${Date.now()}@example.com`,
@@ -173,15 +184,17 @@ describe('Identity Service - Permission Management Operations', () => {
     const user = await ctx.client.identity('/api/users', 'post', {
       body: userData
     });
-    ctx.cleanup.addUser((user as any).userId);
+    const userGrantData = ctx.getData(user);
+    ctx.cleanup.addUser(userGrantData.userId);
 
-    const grantResponse = await ctx.client.identity(`/api/users/${(user as any).userId}/permissions`, 'post', {
+    const grantResponse = await ctx.client.identity(`/api/users/${userGrantData.userId}/permissions`, 'post', {
       body: {
-        permissionId: (permission as any).permissionId
+        permissionId: permissionGrantData.permissionId
       }
     });
+    const grantResponseData = ctx.getData(grantResponse);
 
-    expect((grantResponse as any).success).toBe(true);
+    expect(grantResponseData.success).toBe(true);
   });
 
   test('should revoke permission from user', async () => {
@@ -195,7 +208,8 @@ describe('Identity Service - Permission Management Operations', () => {
     const permission = await ctx.client.identity('/api/permissions', 'post', {
       body: permissionData
     });
-    ctx.cleanup.addPermission((permission as any).permissionId);
+    const permissionRevokeData = ctx.getData(permission);
+    ctx.cleanup.addPermission(permissionRevokeData.permissionId);
 
     const userData = {
       email: `test.user${Date.now()}@example.com`,
@@ -208,17 +222,19 @@ describe('Identity Service - Permission Management Operations', () => {
     const user = await ctx.client.identity('/api/users', 'post', {
       body: userData
     });
-    ctx.cleanup.addUser((user as any).userId);
+    const userRevokeData = ctx.getData(user);
+    ctx.cleanup.addUser(userRevokeData.userId);
 
-    await ctx.client.identity(`/api/users/${(user as any).userId}/permissions`, 'post', {
+    await ctx.client.identity(`/api/users/${userRevokeData.userId}/permissions`, 'post', {
       body: {
-        permissionId: (permission as any).permissionId
+        permissionId: permissionRevokeData.permissionId
       }
     });
 
-    const revokeResponse = await ctx.client.identity(`/api/users/${(user as any).userId}/permissions/${(permission as any).permissionId}`, 'delete');
+    const revokeResponse = await ctx.client.identity(`/api/users/${userRevokeData.userId}/permissions/${permissionRevokeData.permissionId}`, 'delete');
+    const revokeResponseData = ctx.getData(revokeResponse);
 
-    expect((revokeResponse as any).success).toBe(true);
+    expect(revokeResponseData.success).toBe(true);
   });
 
   test('should get user permissions', async () => {
@@ -232,7 +248,8 @@ describe('Identity Service - Permission Management Operations', () => {
     const permission = await ctx.client.identity('/api/permissions', 'post', {
       body: permissionData
     });
-    ctx.cleanup.addPermission((permission as any).permissionId);
+    const permissionListData = ctx.getData(permission);
+    ctx.cleanup.addPermission(permissionListData.permissionId);
 
     const userData = {
       email: `test.user${Date.now()}@example.com`,
@@ -245,21 +262,23 @@ describe('Identity Service - Permission Management Operations', () => {
     const user = await ctx.client.identity('/api/users', 'post', {
       body: userData
     });
-    ctx.cleanup.addUser((user as any).userId);
+    const userListData = ctx.getData(user);
+    ctx.cleanup.addUser(userListData.userId);
 
-    await ctx.client.identity(`/api/users/${(user as any).userId}/permissions`, 'post', {
+    await ctx.client.identity(`/api/users/${userListData.userId}/permissions`, 'post', {
       body: {
-        permissionId: (permission as any).permissionId
+        permissionId: permissionListData.permissionId
       }
     });
 
-    const response = await ctx.client.identity(`/api/users/${(user as any).userId}/permissions`, 'get');
+    const response = await ctx.client.identity(`/api/users/${userListData.userId}/permissions`, 'get');
+    const userPermissionsData = ctx.getData(response);
 
-    expect((response as any).permissions).toBeDefined();
-    expect(Array.isArray((response as any).permissions)).toBe(true);
+    expect(userPermissionsData.permissions).toBeDefined();
+    expect(Array.isArray(userPermissionsData.permissions)).toBe(true);
     
-    const permissionIds = (response as any).permissions.map((p: any) => p.permissionId);
-    expect(permissionIds).toContain((permission as any).permissionId);
+    const permissionIds = userPermissionsData.permissions.map((p: any) => p.permissionId);
+    expect(permissionIds).toContain(permissionListData.permissionId);
   });
 
   test('should check if user has permission', async () => {
@@ -273,7 +292,8 @@ describe('Identity Service - Permission Management Operations', () => {
     const permission = await ctx.client.identity('/api/permissions', 'post', {
       body: permissionData
     });
-    ctx.cleanup.addPermission((permission as any).permissionId);
+    const permissionCheckData = ctx.getData(permission);
+    ctx.cleanup.addPermission(permissionCheckData.permissionId);
 
     const userData = {
       email: `test.user${Date.now()}@example.com`,
@@ -286,20 +306,22 @@ describe('Identity Service - Permission Management Operations', () => {
     const user = await ctx.client.identity('/api/users', 'post', {
       body: userData
     });
-    ctx.cleanup.addUser((user as any).userId);
+    const userCheckData = ctx.getData(user);
+    ctx.cleanup.addUser(userCheckData.userId);
 
-    await ctx.client.identity(`/api/users/${(user as any).userId}/permissions`, 'post', {
+    await ctx.client.identity(`/api/users/${userCheckData.userId}/permissions`, 'post', {
       body: {
-        permissionId: (permission as any).permissionId
+        permissionId: permissionCheckData.permissionId
       }
     });
 
-    const response = await ctx.client.identity(`/api/users/${(user as any).userId}/has-permission`, 'post', {
+    const response = await ctx.client.identity(`/api/users/${userCheckData.userId}/has-permission`, 'post', {
       body: {
         permissionName: permissionData.name
       }
     });
+    const hasPermissionData = ctx.getData(response);
 
-    expect((response as any).hasPermission).toBe(true);
+    expect(hasPermissionData.hasPermission).toBe(true);
   });
 });

--- a/tests/api/features/identity/session-management/happy-path/session-operations.api.spec.ts
+++ b/tests/api/features/identity/session-management/happy-path/session-operations.api.spec.ts
@@ -25,7 +25,8 @@ describe('Identity Service - Session Management Operations', () => {
         password: 'Test123!@#'
       }
     });
-    testUserId = (user as any).userId;
+    const userResponseData = ctx.getData(user);
+    testUserId = userResponseData.userId;
     ctx.cleanup.addUser(testUserId);
 
     // Create a session by logging in
@@ -35,7 +36,8 @@ describe('Identity Service - Session Management Operations', () => {
         password: 'Test123!@#'
       }
     });
-    testSessionId = (loginResponse as any).sessionId;
+    const loginResponseData = ctx.getData(loginResponse);
+    testSessionId = loginResponseData.sessionId;
   });
 
   afterAll(async () => {
@@ -46,23 +48,25 @@ describe('Identity Service - Session Management Operations', () => {
     const response = await ctx.client.identity('/api/sessions/current', 'get');
 
     expect(response).toBeDefined();
-    expect((response as any).sessionId).toBeTruthy();
-    expect((response as any).userId).toBeTruthy();
-    expect((response as any).createdAt).toBeTruthy();
-    expect((response as any).lastActivityAt).toBeTruthy();
-    expect((response as any).ipAddress).toBeTruthy();
-    expect((response as any).userAgent).toBeTruthy();
+    const currentSessionData = ctx.getData(response);
+    expect(currentSessionData.sessionId).toBeTruthy();
+    expect(currentSessionData.userId).toBeTruthy();
+    expect(currentSessionData.createdAt).toBeTruthy();
+    expect(currentSessionData.lastActivityAt).toBeTruthy();
+    expect(currentSessionData.ipAddress).toBeTruthy();
+    expect(currentSessionData.userAgent).toBeTruthy();
   });
 
   test('should list all active sessions for user', async () => {
     const response = await ctx.client.identity(`/api/users/${testUserId}/sessions`, 'get');
 
     expect(response).toBeDefined();
-    expect((response as any).sessions).toBeDefined();
-    expect(Array.isArray((response as any).sessions)).toBe(true);
-    expect((response as any).sessions.length).toBeGreaterThan(0);
+    const sessionsResponseData = ctx.getData(response);
+    expect(sessionsResponseData.sessions).toBeDefined();
+    expect(Array.isArray(sessionsResponseData.sessions)).toBe(true);
+    expect(sessionsResponseData.sessions.length).toBeGreaterThan(0);
     
-    const sessionIds = (response as any).sessions.map((s: any) => s.sessionId);
+    const sessionIds = sessionsResponseData.sessions.map((s: any) => s.sessionId);
     expect(sessionIds).toContain(testSessionId);
   });
 
@@ -70,18 +74,20 @@ describe('Identity Service - Session Management Operations', () => {
     const response = await ctx.client.identity(`/api/sessions/${testSessionId}`, 'get');
 
     expect(response).toBeDefined();
-    expect((response as any).sessionId).toBe(testSessionId);
-    expect((response as any).userId).toBe(testUserId);
-    expect((response as any).isActive).toBe(true);
+    const sessionDetailsData = ctx.getData(response);
+    expect(sessionDetailsData.sessionId).toBe(testSessionId);
+    expect(sessionDetailsData.userId).toBe(testUserId);
+    expect(sessionDetailsData.isActive).toBe(true);
   });
 
   test('should refresh session', async () => {
     const response = await ctx.client.identity(`/api/sessions/${testSessionId}/refresh`, 'post');
 
     expect(response).toBeDefined();
-    expect((response as any).token).toBeTruthy();
-    expect((response as any).refreshToken).toBeTruthy();
-    expect((response as any).expiresAt).toBeTruthy();
+    const refreshResponseData = ctx.getData(response);
+    expect(refreshResponseData.token).toBeTruthy();
+    expect(refreshResponseData.refreshToken).toBeTruthy();
+    expect(refreshResponseData.expiresAt).toBeTruthy();
   });
 
   test('should revoke specific session', async () => {
@@ -97,7 +103,8 @@ describe('Identity Service - Session Management Operations', () => {
         password: 'Test123!@#'
       }
     });
-    ctx.cleanup.addUser((user as any).userId);
+    const newUserData = ctx.getData(user);
+    ctx.cleanup.addUser(newUserData.userId);
 
     const loginResponse = await ctx.client.identity('/api/auth/login', 'post', {
       body: {
@@ -105,12 +112,14 @@ describe('Identity Service - Session Management Operations', () => {
         password: 'Test123!@#'
       }
     });
-    const sessionToRevoke = (loginResponse as any).sessionId;
+    const newLoginResponseData = ctx.getData(loginResponse);
+    const sessionToRevoke = newLoginResponseData.sessionId;
 
     const response = await ctx.client.identity(`/api/sessions/${sessionToRevoke}/revoke`, 'post');
 
     expect(response).toBeDefined();
-    expect((response as any).success).toBe(true);
+    const revokeResponseData = ctx.getData(response);
+    expect(revokeResponseData.success).toBe(true);
 
     // Verify session is revoked
     await expect(
@@ -124,8 +133,9 @@ describe('Identity Service - Session Management Operations', () => {
     const response = await ctx.client.identity(`/api/users/${testUserId}/sessions/revoke-all`, 'post');
 
     expect(response).toBeDefined();
-    expect((response as any).success).toBe(true);
-    expect((response as any).revokedCount).toBeGreaterThan(0);
+    const revokeAllResponseData = ctx.getData(response);
+    expect(revokeAllResponseData.success).toBe(true);
+    expect(revokeAllResponseData.revokedCount).toBeGreaterThan(0);
   });
 
   test('should track session activity', async () => {
@@ -137,7 +147,8 @@ describe('Identity Service - Session Management Operations', () => {
     });
 
     expect(response).toBeDefined();
-    expect((response as any).success).toBe(true);
+    const activityResponseData = ctx.getData(response);
+    expect(activityResponseData.success).toBe(true);
   });
 
   test('should get session activity history', async () => {
@@ -152,9 +163,10 @@ describe('Identity Service - Session Management Operations', () => {
     const response = await ctx.client.identity(`/api/sessions/${testSessionId}/activity`, 'get');
 
     expect(response).toBeDefined();
-    expect((response as any).activities).toBeDefined();
-    expect(Array.isArray((response as any).activities)).toBe(true);
-    expect((response as any).activities.length).toBeGreaterThan(0);
+    const activityHistoryData = ctx.getData(response);
+    expect(activityHistoryData.activities).toBeDefined();
+    expect(Array.isArray(activityHistoryData.activities)).toBe(true);
+    expect(activityHistoryData.activities.length).toBeGreaterThan(0);
   });
 
   test('should validate session token', async () => {
@@ -165,9 +177,10 @@ describe('Identity Service - Session Management Operations', () => {
     });
 
     expect(response).toBeDefined();
-    expect((response as any).valid).toBe(true);
-    expect((response as any).sessionId).toBeTruthy();
-    expect((response as any).userId).toBeTruthy();
+    const validateResponseData = ctx.getData(response);
+    expect(validateResponseData.valid).toBe(true);
+    expect(validateResponseData.sessionId).toBeTruthy();
+    expect(validateResponseData.userId).toBeTruthy();
   });
 
   test('should handle session timeout', async () => {
@@ -183,7 +196,8 @@ describe('Identity Service - Session Management Operations', () => {
         password: 'Test123!@#'
       }
     });
-    ctx.cleanup.addUser((user as any).userId);
+    const timeoutUserData = ctx.getData(user);
+    ctx.cleanup.addUser(timeoutUserData.userId);
 
     const loginResponse = await ctx.client.identity('/api/auth/login', 'post', {
       body: {
@@ -193,32 +207,36 @@ describe('Identity Service - Session Management Operations', () => {
       }
     });
 
-    const shortSession = (loginResponse as any).sessionId;
+    const timeoutLoginData = ctx.getData(loginResponse);
+    const shortSession = timeoutLoginData.sessionId;
 
     // Wait for timeout (in real test, would wait actual timeout period)
     // For now, just check the session details
     const sessionDetails = await ctx.client.identity(`/api/sessions/${shortSession}`, 'get');
 
     expect(sessionDetails).toBeDefined();
-    expect((sessionDetails as any).sessionTimeout).toBe(1);
+    const timeoutSessionDetails = ctx.getData(sessionDetails);
+    expect(timeoutSessionDetails.sessionTimeout).toBe(1);
   });
 
   test('should get session statistics', async () => {
     const response = await ctx.client.identity(`/api/users/${testUserId}/sessions/stats`, 'get');
 
     expect(response).toBeDefined();
-    expect((response as any).totalSessions).toBeDefined();
-    expect((response as any).activeSessions).toBeDefined();
-    expect((response as any).averageSessionDuration).toBeDefined();
-    expect((response as any).lastLoginAt).toBeDefined();
+    const statsResponseData = ctx.getData(response);
+    expect(statsResponseData.totalSessions).toBeDefined();
+    expect(statsResponseData.activeSessions).toBeDefined();
+    expect(statsResponseData.averageSessionDuration).toBeDefined();
+    expect(statsResponseData.lastLoginAt).toBeDefined();
   });
 
   test('should detect concurrent sessions', async () => {
     const response = await ctx.client.identity(`/api/users/${testUserId}/sessions/concurrent`, 'get');
 
     expect(response).toBeDefined();
-    expect((response as any).concurrentSessions).toBeDefined();
-    expect((response as any).maxAllowed).toBeDefined();
-    expect((response as any).exceedsLimit).toBeDefined();
+    const concurrentResponseData = ctx.getData(response);
+    expect(concurrentResponseData.concurrentSessions).toBeDefined();
+    expect(concurrentResponseData.maxAllowed).toBeDefined();
+    expect(concurrentResponseData.exceedsLimit).toBeDefined();
   });
 });

--- a/tests/api/features/tenant-management/onboarding/edge-cases/duplicate-tenant.api.spec.ts
+++ b/tests/api/features/tenant-management/onboarding/edge-cases/duplicate-tenant.api.spec.ts
@@ -21,7 +21,8 @@ describe('Tenant Creation - Duplicate Prevention API Tests', () => {
     const created = await ctx.client.tenant('/api/tenants', 'post', {
       body: tenantData
     });
-    ctx.cleanup.addTenant((created as any).id);
+    const duplicateNameTestData = ctx.getData(created);
+    ctx.cleanup.addTenant(duplicateNameTestData.id);
 
     const duplicateData = {
       ...TestDataFactory.tenant(),
@@ -44,7 +45,8 @@ describe('Tenant Creation - Duplicate Prevention API Tests', () => {
     const created = await ctx.client.tenant('/api/tenants', 'post', {
       body: tenantData
     });
-    ctx.cleanup.addTenant((created as any).id);
+    const duplicateDomainTestData = ctx.getData(created);
+    ctx.cleanup.addTenant(duplicateDomainTestData.id);
 
     const duplicateData = {
       ...TestDataFactory.tenant(),
@@ -66,7 +68,8 @@ describe('Tenant Creation - Duplicate Prevention API Tests', () => {
     const created = await ctx.client.tenant('/api/tenants', 'post', {
       body: tenantData
     });
-    ctx.cleanup.addTenant((created as any).id);
+    const duplicateEmailTestData = ctx.getData(created);
+    ctx.cleanup.addTenant(duplicateEmailTestData.id);
 
     const duplicateData = {
       ...TestDataFactory.tenant(),
@@ -88,12 +91,14 @@ describe('Tenant Creation - Duplicate Prevention API Tests', () => {
     const created = await ctx.client.tenant('/api/tenants', 'post', {
       body: tenantData
     });
-    ctx.cleanup.addTenant((created as any).id);
+    const tenantExistsTestData = ctx.getData(created);
+    ctx.cleanup.addTenant(tenantExistsTestData.id);
 
     const response = await ctx.client.tenant(`/api/tenants/by-name/${tenantData.tenantName}`, 'get');
     
     expect(response).toBeDefined();
-    expect((response as any).id).toBe((created as any).id);
+    const responseData = ctx.getData(response);
+    expect(responseData.id).toBe(tenantExistsTestData.id);
   });
 
   test('should verify tenant exists check returns false for non-existing tenant', async () => {

--- a/tests/api/features/tenant-management/onboarding/happy-path/tenant-creation.api.spec.ts
+++ b/tests/api/features/tenant-management/onboarding/happy-path/tenant-creation.api.spec.ts
@@ -106,14 +106,16 @@ describe('Business Feature: Tenant Onboarding', () => {
     const created = await ctx.client.tenant('/api/tenants', 'post', {
       body: tenantData
     });
-    ctx.cleanup.addTenant((created as any).id);
+    const activationTestData = ctx.getData(created);
+    ctx.cleanup.addTenant(activationTestData.id);
 
     await new Promise(resolve => setTimeout(resolve, 2000));
 
-    const activated = await ctx.client.tenant(`/api/tenants/${(created as any).id}/activate`, 'post');
+    const activated = await ctx.client.tenant(`/api/tenants/${activationTestData.id}/activate`, 'post');
+    const activatedData = ctx.getData(activated);
 
-    expect((activated as any).id).toBe((created as any).id);
-    expect((activated as any).status).toBe('Active');
+    expect(activatedData.id).toBe(activationTestData.id);
+    expect(activatedData.status).toBe('Active');
   });
 
   test('should successfully send welcome email after tenant activation', async () => {
@@ -121,13 +123,14 @@ describe('Business Feature: Tenant Onboarding', () => {
     const created = await ctx.client.tenant('/api/tenants', 'post', {
       body: tenantData
     });
-    ctx.cleanup.addTenant((created as any).id);
+    const welcomeEmailTestData = ctx.getData(created);
+    ctx.cleanup.addTenant(welcomeEmailTestData.id);
     
     await new Promise(resolve => setTimeout(resolve, 2000));
-    await ctx.client.tenant(`/api/tenants/${(created as any).id}/activate`, 'post');
+    await ctx.client.tenant(`/api/tenants/${welcomeEmailTestData.id}/activate`, 'post');
 
     await expect(
-      ctx.client.tenant(`/api/tenants/${(created as any).id}/resend-welcome`, 'post')
+      ctx.client.tenant(`/api/tenants/${welcomeEmailTestData.id}/resend-welcome`, 'post')
     ).resolves.toBeDefined();
   });
 
@@ -136,16 +139,18 @@ describe('Business Feature: Tenant Onboarding', () => {
     const created = await ctx.client.tenant('/api/tenants', 'post', {
       body: tenantData
     });
-    ctx.cleanup.addTenant((created as any).id);
+    const listTenantTestData = ctx.getData(created);
+    ctx.cleanup.addTenant(listTenantTestData.id);
 
     const response = await ctx.client.tenant('/api/tenants', 'get', {
       params: { query: { pageSize: 50, pageNumber: 1 } }
     });
 
-    expect((response as any).tenants).toBeDefined();
-    expect(Array.isArray((response as any).tenants)).toBe(true);
+    const listResponseData = ctx.getData(response);
+    expect(listResponseData.tenants).toBeDefined();
+    expect(Array.isArray(listResponseData.tenants)).toBe(true);
     
-    const found = (response as any).tenants.find((t: any) => t.id === (created as any).id);
+    const found = listResponseData.tenants.find((t: any) => t.id === listTenantTestData.id);
     expect(found).toBeDefined();
     expect(found.tenantName).toBe(tenantData.tenantName);
   });

--- a/tests/api/features/tenant-management/onboarding/happy-path/typed-tenant-creation.api.spec.ts
+++ b/tests/api/features/tenant-management/onboarding/happy-path/typed-tenant-creation.api.spec.ts
@@ -50,12 +50,12 @@ describe('Tenant Creation - Using Typed NPM Packages', () => {
 
     // Assert - Response is typed based on OpenAPI schema
     expect(response).toBeDefined();
-    expect((response as any).id).toBeTruthy();
-    expect((response as any).tenantName).toBe(tenantData.tenantName);
-    expect((response as any).status).toBe('Pending');
+    expect(response.data.id).toBeTruthy();
+    expect(response.data.tenantName).toBe(tenantData.tenantName);
+    expect(response.data.status).toBe('Pending');
     
     // Track for cleanup
-    createdTenantIds.push((response as any).id);
+    createdTenantIds.push(response.data.id);
   });
 
   test('should get tenant by ID with typed client', async () => {
@@ -76,7 +76,7 @@ describe('Tenant Creation - Using Typed NPM Packages', () => {
       }
     });
     
-    const tenantId = (createResponse as any).id;
+    const tenantId = createResponse.data.id;
     createdTenantIds.push(tenantId);
 
     // Act - Get tenant using typed endpoint
@@ -84,8 +84,8 @@ describe('Tenant Creation - Using Typed NPM Packages', () => {
 
     // Assert
     expect(getResponse).toBeDefined();
-    expect((getResponse as any).id).toBe(tenantId);
-    expect((getResponse as any).tenantName).toBe(tenantData.tenantName);
+    expect(getResponse.data.id).toBe(tenantId);
+    expect(getResponse.data.tenantName).toBe(tenantData.tenantName);
   });
 
   test('should list tenants with typed client', async () => {
@@ -101,10 +101,10 @@ describe('Tenant Creation - Using Typed NPM Packages', () => {
 
     // Assert - Response structure is typed
     expect(response).toBeDefined();
-    expect(Array.isArray((response as any).tenants)).toBe(true);
-    expect((response as any).totalCount).toBeDefined();
-    expect((response as any).pageSize).toBeDefined();
-    expect((response as any).pageNumber).toBeDefined();
+    expect(Array.isArray(response.data.tenants)).toBe(true);
+    expect(response.data.totalCount).toBeDefined();
+    expect(response.data.pageSize).toBeDefined();
+    expect(response.data.pageNumber).toBeDefined();
   });
 
   test('should activate tenant with typed client', async () => {
@@ -125,7 +125,7 @@ describe('Tenant Creation - Using Typed NPM Packages', () => {
       }
     });
     
-    const tenantId = (createResponse as any).id;
+    const tenantId = createResponse.data.id;
     createdTenantIds.push(tenantId);
 
     // Wait for tenant to be ready
@@ -136,8 +136,8 @@ describe('Tenant Creation - Using Typed NPM Packages', () => {
 
     // Assert
     expect(activateResponse).toBeDefined();
-    expect((activateResponse as any).id).toBe(tenantId);
-    expect((activateResponse as any).status).toBe('Active');
+    expect(activateResponse.data.id).toBe(tenantId);
+    expect(activateResponse.data.status).toBe('Active');
   });
 
   test('should handle typed error responses for duplicate tenant', async () => {
@@ -157,7 +157,7 @@ describe('Tenant Creation - Using Typed NPM Packages', () => {
         country: tenantData.country
       }
     });
-    createdTenantIds.push((firstResponse as any).id);
+    createdTenantIds.push(firstResponse.data.id);
 
     // Act & Assert - Try to create duplicate
     try {

--- a/tests/api/features/tenant-management/suspension/happy-path/tenant-suspension.api.spec.ts
+++ b/tests/api/features/tenant-management/suspension/happy-path/tenant-suspension.api.spec.ts
@@ -22,14 +22,15 @@ describe('Tenant Management - Suspension Operations', () => {
     const created = await ctx.client.tenant('/api/tenants', 'post', {
       body: tenantData
     });
-    ctx.cleanup.addTenant((created as any).id);
+    const createdTenantData = ctx.getData(created);
+    ctx.cleanup.addTenant(createdTenantData.id);
 
     // Activate tenant first
     await new Promise(resolve => setTimeout(resolve, 2000));
-    await ctx.client.tenant(`/api/tenants/${(created as any).id}/activate`, 'post');
+    await ctx.client.tenant(`/api/tenants/${createdTenantData.id}/activate`, 'post');
 
     // Now suspend it
-    const response = await ctx.client.tenant(`/api/tenants/${(created as any).id}/suspend`, 'post', {
+    const response = await ctx.client.tenant(`/api/tenants/${createdTenantData.id}/suspend`, 'post', {
       body: {
         reason: 'Non-payment'
       }
@@ -38,8 +39,9 @@ describe('Tenant Management - Suspension Operations', () => {
     expect(response).toBeDefined();
 
     // Verify tenant is suspended
-    const tenant = await ctx.client.tenant(`/api/tenants/${(created as any).id}`, 'get');
-    expect((tenant as any).tenant.status).toBe('Suspended');
+    const tenant = await ctx.client.tenant(`/api/tenants/${createdTenantData.id}`, 'get');
+    const suspendedTenantData = ctx.getData(tenant);
+    expect(suspendedTenantData.tenant.status).toBe('Suspended');
   });
 
   test('should reactivate a suspended tenant', async () => {
@@ -47,21 +49,23 @@ describe('Tenant Management - Suspension Operations', () => {
     const created = await ctx.client.tenant('/api/tenants', 'post', {
       body: tenantData
     });
-    ctx.cleanup.addTenant((created as any).id);
+    const reactivateTestData = ctx.getData(created);
+    ctx.cleanup.addTenant(reactivateTestData.id);
 
     // Activate, then suspend
     await new Promise(resolve => setTimeout(resolve, 2000));
-    await ctx.client.tenant(`/api/tenants/${(created as any).id}/activate`, 'post');
-    await ctx.client.tenant(`/api/tenants/${(created as any).id}/suspend`, 'post', {
+    await ctx.client.tenant(`/api/tenants/${reactivateTestData.id}/activate`, 'post');
+    await ctx.client.tenant(`/api/tenants/${reactivateTestData.id}/suspend`, 'post', {
       body: { reason: 'Test suspension' }
     });
 
     // Reactivate
-    const response = await ctx.client.tenant(`/api/tenants/${(created as any).tenant_id}/activate`, 'post', {
+    const response = await ctx.client.tenant(`/api/tenants/${reactivateTestData.tenant_id}/activate`, 'post', {
       body: {}
     });
 
-    expect((response as any).tenant.status).toBe('Active');
+    const reactivatedTenantData = ctx.getData(response);
+    expect(reactivatedTenantData.tenant.status).toBe('Active');
   });
 
   test('should delete a tenant', async () => {
@@ -69,8 +73,9 @@ describe('Tenant Management - Suspension Operations', () => {
     const created = await ctx.client.tenant('/api/tenants', 'post', {
       body: tenantData
     });
+    const deleteTenantData = ctx.getData(created);
 
-    const response = await ctx.client.tenant(`/api/tenants/${(created as any).id}`, 'delete', {
+    const response = await ctx.client.tenant(`/api/tenants/${deleteTenantData.id}`, 'delete', {
       body: {
         reason: 'Test deletion'
       }
@@ -79,7 +84,8 @@ describe('Tenant Management - Suspension Operations', () => {
     expect(response).toBeDefined();
 
     // Verify tenant is deleted (soft delete)
-    const tenant = await ctx.client.tenant(`/api/tenants/${(created as any).id}`, 'get');
-    expect((tenant as any).tenant.status).toBe('Deleted');
+    const tenant = await ctx.client.tenant(`/api/tenants/${deleteTenantData.id}`, 'get');
+    const deletedTenantData = ctx.getData(tenant);
+    expect(deletedTenantData.tenant.status).toBe('Deleted');
   });
 });


### PR DESCRIPTION
## Summary
Completed the migration of all remaining test files to use the `getData()` helper method for handling wrapped API responses, eliminating all instances of unsafe `(response as any)` type casting.

## Problem
After implementing X-Correlation-ID tracking and GlobalAuthManager for reduced authentication calls, the API responses changed from direct format to wrapped format. While some test files were already updated, many still used the unsafe `(response as any)` pattern.

## Solution
Systematically migrated all remaining test files across three service domains to use the proper `getData()` helper method:

### Identity Service Tests (7 files)
- ✅ `2fa-operations.api.spec.ts`
- ✅ `invitation-operations.api.spec.ts`
- ✅ `session-operations.api.spec.ts`
- ✅ `permission-crud.api.spec.ts`
- ✅ `typed-login.api.spec.ts`
- ✅ `audit-operations.api.spec.ts`
- ✅ `password-reset.api.spec.ts`

### Tenant Management Tests (4 files)
- ✅ `tenant-suspension.api.spec.ts`
- ✅ `duplicate-tenant.api.spec.ts`
- ✅ `tenant-creation.api.spec.ts`
- ✅ `typed-tenant-creation.api.spec.ts`

### Client Management Tests (3 files)
- ✅ `group-operations.api.spec.ts`
- ✅ `typed-client-crud.api.spec.ts`
- ✅ `user-client-associations.api.spec.ts`

## Implementation Details
- Replaced all `(response as any).property` patterns with `ctx.getData(response)` calls
- Used unique variable names to avoid conflicts (e.g., `responseData`, `createdData`, `loginResponseData`)
- Properly handled TypedApiClient responses that use `response.data` structure
- Maintained original test logic while improving type safety

## Testing
- [x] Verified no `(response as any)` patterns remain in the codebase
- [x] All file modifications completed successfully
- [x] TypeScript compilation checked (existing errors unrelated to changes)
- [x] Code follows established patterns from previously migrated files

## Benefits
- **Type Safety**: Eliminated unsafe type casting with `as any`
- **Consistency**: All tests now use the same response handling pattern
- **Maintainability**: Clear variable naming and proper helper usage
- **Future-proof**: Seamlessly handles X-Correlation-ID tracking

Fixes #1