### PR TITLE
fix: Correct TypedApiClient import path in api-test-base

### DIFF
--- a/tests/api/support/helpers/api-test-base.ts
+++ b/tests/api/support/helpers/api-test-base.ts
@@ -3,7 +3,7 @@
  * Supports both Global Authentication Manager and Multi-User Context Authentication
  */
 
-import { TypedApiClient, ApiResponse } from '../clients/typed-api-client-enhanced';
+import { TypedApiClient, ApiResponse } from '../clients/typed-api-client';
 import { GlobalAuthManager } from '../auth/global-auth-manager';
 import { MultiUserAuthManager, UserContext } from '../auth/multi-user-auth-manager';
 import { TestContextHelper } from '../auth/test-context-helper';


### PR DESCRIPTION
## Summary
- Fixed incorrect import path from `../clients/typed-api-client-enhanced` to `../clients/typed-api-client`
- The enhanced client file was never committed to the repository causing module not found errors
- This resolves the pipeline failure where tests couldn't run due to missing imports

## Test plan
- [x] Verified the correct `typed-api-client.ts` file exists in the clients directory
- [x] Confirmed the import path matches the actual file structure
- [x] This should allow all BDD tests to run without module resolution errors

This is a critical fix to restore the BDD test pipeline functionality after our field naming improvements in PR #15.