### PR TITLE
fix: Generate valid 15-digit ICE numbers in client management tests

### DIFF
--- a/tests/api/features/client-management/crud-operations/happy-path/typed-client-crud.api.spec.ts
+++ b/tests/api/features/client-management/crud-operations/happy-path/typed-client-crud.api.spec.ts
@@ -44,17 +44,18 @@ describe('Client Management - CRUD with Typed NPM Packages', () => {
   test('should create client with typed client from @btshift/client-management-types', async () => {
     
     // Arrange
+    const timestamp = Date.now();
     const clientData = {
-      companyName: `Test Client ${Date.now()}`,
+      companyName: `Test Client ${timestamp}`,
       country: 'Morocco',
       address: '123 Test Street, Casablanca',
-      iceNumber: `ICE${Date.now()}`,
-      rcNumber: `RC${Date.now()}`,
-      vatNumber: `VAT${Date.now()}`,
-      cnssNumber: `CNSS${Date.now()}`,
+      iceNumber: timestamp.toString().padStart(15, '0'), // Generate exactly 15 digits for valid ICE number
+      rcNumber: `RC${timestamp}`,
+      vatNumber: `VAT${timestamp}`,
+      cnssNumber: `CNSS${timestamp}`,
       industry: 'Technology',
-      adminContactPerson: `admin-${Date.now()}@test.com`,
-      billingContactPerson: `billing-${Date.now()}@test.com`
+      adminContactPerson: `admin-${timestamp}@test.com`,
+      billingContactPerson: `billing-${timestamp}@test.com`
     };
 
     // Act - Using the typed client from npm package


### PR DESCRIPTION
## Summary
Fixes BDD test to generate valid 15-digit ICE numbers that comply with the server-side validation added in client-management-service.

## Problem
After adding ICE number length validation in client-management-service (PR #43), BDD tests were failing because they generated invalid ICE numbers:
- **Old format:** `ICE${Date.now()}` produced strings like "ICE1757675696247" (16+ characters)
- **Database constraint:** ICE numbers must be exactly 15 characters
- **Result:** Tests failed with validation error instead of the previous database constraint violation

## Solution
Updated the test data generation to create valid 15-digit ICE numbers:
```typescript
// Before
iceNumber: `ICE${Date.now()}`,  // Produces 16+ characters

// After  
const timestamp = Date.now();
iceNumber: timestamp.toString().padStart(15, '0'),  // Exactly 15 digits
```

## Technical Details
- **File Changed:** `tests/api/features/client-management/crud-operations/happy-path/typed-client-crud.api.spec.ts`
- **Line 52:** Updated ICE number generation logic
- **Format:** Uses timestamp padded with leading zeros to ensure exactly 15 digits
- **Standard:** Aligns with Moroccan ICE number requirement (15 digits)

## Testing
- The change ensures ICE numbers are always exactly 15 characters
- Test will now pass the server-side validation added in client-management-service
- No other test data fields were affected

## Related
- Fixes test failures introduced by BTShift/client-management-service#43
- Completes the fix for PostgreSQL constraint violation from correlation ID `aa930696-6b07-447c-9fed-b5ea878acb8e`