### PR TITLE
chore: Update service type packages for proto changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
-        "@btshift/client-management-types": "^3.0.5",
-        "@btshift/identity-types": "^6.1.12",
+        "@btshift/client-management-types": "^3.0.6",
+        "@btshift/identity-types": "^7.0.0",
         "@btshift/tenant-management-types": "^2.0.0"
       },
       "devDependencies": {
@@ -77,15 +77,15 @@
       }
     },
     "node_modules/@btshift/client-management-types": {
-      "version": "3.0.5",
-      "resolved": "https://npm.pkg.github.com/download/@btshift/client-management-types/3.0.5/fe6541cf1c83bed209295ecd15a88d8718621627",
-      "integrity": "sha512-FkRDwocA2Gyz11+89wS1C6GqxZpSGZwCVYZoxZtkjeHPQJF8k+4Ws5clkbVblxGU+Glwf7rpNGJr+a+/w1ZNrw==",
+      "version": "3.0.6",
+      "resolved": "https://npm.pkg.github.com/download/@btshift/client-management-types/3.0.6/285ea160339100ac9b28e980706d880c23aa4d2e",
+      "integrity": "sha512-VjWZzvGQS7TSSsB1/gkhQu8uYpFB6DEkyUQx2YuIZPsEbleeSQKFHHuAjc8jayp1UDzS92HullIDmUBod0DmUw==",
       "license": "MIT"
     },
     "node_modules/@btshift/identity-types": {
-      "version": "6.1.12",
-      "resolved": "https://npm.pkg.github.com/download/@btshift/identity-types/6.1.12/8fde2923a919b6e06a48679cab91318645cac5aa",
-      "integrity": "sha512-Mgc1mCq6o37WRwTRYF9Fh6RwrUm0h5hl0UQzG8ojRYCXTKBGaS7xwock84XqAGdFi3XqjjEWi1d9fn/6ulCEAg==",
+      "version": "7.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@btshift/identity-types/7.0.0/6eb4a4a72a1d4e99684a4410fb4cc5d934392457",
+      "integrity": "sha512-D5vY/yCuqJ8RGw9018sBTHUT390dGCY2tlO1BDPFaypVkwFE2rlZ7L6faUy1VVv84QpYMHwRVp1YTOqAABdNAw==",
       "license": "MIT"
     },
     "node_modules/@btshift/tenant-management-types": {

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "npm": ">=8.0.0"
   },
   "dependencies": {
-    "@btshift/client-management-types": "^3.0.5",
-    "@btshift/identity-types": "^6.1.12",
+    "@btshift/client-management-types": "^3.0.6",
+    "@btshift/identity-types": "^7.0.0",
     "@btshift/tenant-management-types": "^2.0.0"
   }
 }


### PR DESCRIPTION
## Summary
Update npm packages to get the latest type definitions that match the backend proto changes from the security fixes.

## Changes
- **@btshift/identity-types**: 6.1.12 → 7.0.0
- **@btshift/client-management-types**: 3.0.5 → 3.0.6

## Context
These packages were published after the security fixes (PR #46 for client-management and PR #125 for identity-service) that removed `tenant_id` fields from request messages. The new versions include:
- Correct field numbering after tenant_id removal
- Updated type definitions without tenant_id parameters
- Compatible interfaces for JWT-based tenant context

## Related PRs
- BDD Test Updates: #19 (already merged)
- Client Management Security Fix: BTShift/client-management-service#46
- Identity Service Security Fix: BTShift/identity-service#125

## Testing
- ✅ Packages installed successfully
- ✅ No new TypeScript compilation errors
- ✅ Compatible with the test changes from PR #19