### PR TITLE
fix: Add X-Test-Mode header injection to prevent test email delivery

### DIFF
--- a/lib/helpers/base-api-client.ts
+++ b/lib/helpers/base-api-client.ts
@@ -48,6 +48,7 @@ export abstract class BaseApiClient {
       ...options,
       headers: {
         'X-Correlation-ID': correlationId,
+        'X-Test-Mode': 'true', // Always inject test mode header during BDD tests
         ...(testContext && { 'X-Test-Context': testContext }),
         ...(this.authToken && { 'Authorization': `Bearer ${this.authToken}` }),
         ...options.headers

--- a/tests/api/support/clients/typed-api-client.ts
+++ b/tests/api/support/clients/typed-api-client.ts
@@ -88,6 +88,7 @@ export class TypedApiClient {
       // Prepare headers
       const headers: Record<string, string> = {
         'X-Correlation-ID': correlationId,
+        'X-Test-Mode': 'true', // Always inject test mode header during BDD tests
         ...(testContext && { 'X-Test-Context': testContext }),
         ...(this.authToken && { 'Authorization': `Bearer ${this.authToken}` }),
         ...options.headers


### PR DESCRIPTION
## Summary
- Automatically inject `X-Test-Mode: true` header in all API requests during BDD test execution
- Prevents test emails from being delivered by backend services
- Headers propagate through API Gateway to all microservices

## Problem
BDD tests were using @example.com emails which caused bounce rates in the production email service. Backend services need a way to identify test requests and prevent email delivery.

## Solution
Updated both API client implementations to automatically inject the `X-Test-Mode: true` header:

### Files Modified
- `tests/api/support/clients/typed-api-client.ts` - Main API client used by tests
- `lib/helpers/base-api-client.ts` - Base class for other API clients

### Implementation Details
- Header is injected at the client level before all HTTP requests
- Works with existing correlation ID and test context headers
- Propagates through API Gateway to all backend services
- Can be overridden if needed by passing custom headers

## Testing
- [x] Headers are automatically injected in all API calls
- [x] Existing functionality preserved (correlation ID, auth, test context)
- [x] TypeScript compilation passes
- [x] Changes are backward compatible

## Verification
All API requests made by the BDD test suite will now include:
```
X-Test-Mode: true
X-Correlation-ID: [uuid]
X-Test-Context: [test context if available]
Authorization: Bearer [token if authenticated]
```

## Dependencies
- None - works independently with any backend that checks the X-Test-Mode header
- Backend services should check for this header and skip email delivery when present

Fixes #27